### PR TITLE
fix: category_sounds throwing a TypeError exception

### DIFF
--- a/src/soundpadrc/soundpadrc.py
+++ b/src/soundpadrc/soundpadrc.py
@@ -84,7 +84,7 @@ class Soundpad:
         if not data:
             return {}
         xml_data = data.decode("utf-8")
-        xml_dict = xmltodict.parse(xml_data)
+        xml_dict = xmltodict.parse(xml_data, force_list={"Sound"})
         sounds = {}
         for sound in xml_dict["Categories"]["Category"]["Sound"]:
             sounds[sound["@index"]] = sound["@title"]


### PR DESCRIPTION
For some reason the "sound" in for loop becomes a string, not a dict. This change fixes that behavior.

Before it throws a TypeError exception: "string indices must be integers, not 'str'"